### PR TITLE
Show help

### DIFF
--- a/args.go
+++ b/args.go
@@ -15,8 +15,9 @@ type GlobalArgs struct {
 	commands     *group.Group
 	commandFlags []string
 
-	subCommand     string
-	subCommandArgs []string
+	subCommand      string
+	subCommandArgs  []string
+	subCommandFlags []string
 
 	isHelp, isVersion, isDebug         bool
 	requiresInstall, requiresUninstall bool
@@ -40,6 +41,11 @@ func (a *GlobalArgs) SubCommand() string {
 // SubCommandArgs returns the sub command arguments.
 func (a *GlobalArgs) SubCommandArgs() []string {
 	return a.subCommandArgs
+}
+
+// SubCommandFlags returns the sub command flags.
+func (a *GlobalArgs) SubCommandFlags() []string {
+	return a.subCommandFlags
 }
 
 // CommandFlags returns the command arguments.
@@ -170,9 +176,31 @@ func (a *GlobalArgs) Process(args []string) error {
 			}
 
 			// The remaining processed the subCommand arguments
-			a.subCommandArgs = processed[i+1:]
+
+			a.subCommandArgs = removeFlags(processed[i+1:])
+			a.subCommandFlags = removeNonFlags(processed[i+1:])
 		}
 	}
 
 	return nil
+}
+
+func removeFlags(args []string) []string {
+	var result []string
+	for _, v := range args {
+		if !strings.HasPrefix(v, "-") {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+func removeNonFlags(args []string) []string {
+	var result []string
+	for _, v := range args {
+		if strings.HasPrefix(v, "-") {
+			result = append(result, v)
+		}
+	}
+	return result
 }

--- a/args.go
+++ b/args.go
@@ -21,6 +21,7 @@ type GlobalArgs struct {
 	isHelp, isVersion, isDebug         bool
 	requiresInstall, requiresUninstall bool
 	requiresNoColor                    bool
+	requiresNoSubKeys                  bool
 }
 
 // NewGlobalArgs creates a new GlobalArgs type for processing arguments passed
@@ -77,6 +78,11 @@ func (a *GlobalArgs) RequiresNoColor() bool {
 	return a.requiresNoColor
 }
 
+// RequiresNoSubKeys returns if the help should include subkeys.
+func (a *GlobalArgs) RequiresNoSubKeys() bool {
+	return a.requiresNoSubKeys
+}
+
 // Process consumes the arguments and correctly separates them between global
 // flags and arguments and command flags and arguments.
 func (a *GlobalArgs) Process(args []string) error {
@@ -96,6 +102,8 @@ func (a *GlobalArgs) Process(args []string) error {
 			a.isDebug = true
 		case "--no-color":
 			a.requiresNoColor = true
+		case "--no-sub-keys":
+			a.requiresNoSubKeys = true
 		case "--autocomplete-install":
 			a.requiresInstall = true
 		case "--autocomplete-uninstall":

--- a/args_test.go
+++ b/args_test.go
@@ -134,8 +134,6 @@ func TestGlobalArgs(t *testing.T) {
 		}
 	})
 
-	//
-
 	t.Run("command args", func(t *testing.T) {
 		group := group.New()
 		group.Add("a b", nil)
@@ -168,7 +166,10 @@ func TestGlobalArgs(t *testing.T) {
 		if expected, actual := "a b", args.SubCommand(); expected != actual {
 			t.Errorf("expected: %v, actual: %v", expected, actual)
 		}
-		if expected, actual := []string{"c", "--flag"}, args.SubCommandArgs(); !reflect.DeepEqual(expected, actual) {
+		if expected, actual := []string{"c"}, args.SubCommandArgs(); !reflect.DeepEqual(expected, actual) {
+			t.Errorf("expected: %v, actual: %v", expected, actual)
+		}
+		if expected, actual := []string{"--flag"}, args.SubCommandFlags(); !reflect.DeepEqual(expected, actual) {
 			t.Errorf("expected: %v, actual: %v", expected, actual)
 		}
 		if expected, actual := []string(nil), args.CommandFlags(); !reflect.DeepEqual(expected, actual) {
@@ -188,7 +189,10 @@ func TestGlobalArgs(t *testing.T) {
 		if expected, actual := "a b", args.SubCommand(); expected != actual {
 			t.Errorf("expected: %v, actual: %v", expected, actual)
 		}
-		if expected, actual := []string{"--flag", "c"}, args.SubCommandArgs(); !reflect.DeepEqual(expected, actual) {
+		if expected, actual := []string{"c"}, args.SubCommandArgs(); !reflect.DeepEqual(expected, actual) {
+			t.Errorf("expected: %v, actual: %v", expected, actual)
+		}
+		if expected, actual := []string{"--flag"}, args.SubCommandFlags(); !reflect.DeepEqual(expected, actual) {
 			t.Errorf("expected: %v, actual: %v", expected, actual)
 		}
 		if expected, actual := []string(nil), args.CommandFlags(); !reflect.DeepEqual(expected, actual) {

--- a/cli.go
+++ b/cli.go
@@ -376,7 +376,7 @@ func (c *CLI) subCommandParent() string {
 }
 
 func (c *CLI) writeHelp(command string) (Errno, error) {
-	children, err := FindChildren(c.commands, command)
+	children, err := FindChildren(c.commands, command, !c.args.RequiresNoSubKeys())
 	if err != nil {
 		return EPerm, errors.WithStack(err)
 	}
@@ -405,6 +405,7 @@ func (c *CLI) writeHelp(command string) (Errno, error) {
 		help.OptionHint(hint),
 		help.OptionColor(!c.args.RequiresNoColor()),
 		help.OptionTemplate(help.BasicHelpTemplate),
+		help.OptionShowHelp(hint == ""),
 	)
 	if err != nil {
 		return EPerm, errors.WithStack(err)
@@ -416,7 +417,7 @@ func (c *CLI) writeHelp(command string) (Errno, error) {
 func (c *CLI) commandHelp(command Command, operatorErr string) (Errno, error) {
 	subCommand := c.args.SubCommand()
 
-	children, err := FindChildren(c.commands, subCommand)
+	children, err := FindChildren(c.commands, subCommand, !c.args.RequiresNoSubKeys())
 	if err != nil {
 		return EPerm, errors.WithStack(err)
 	}
@@ -452,6 +453,7 @@ func (c *CLI) commandHelp(command Command, operatorErr string) (Errno, error) {
 		help.OptionFlags(flags),
 		help.OptionUsages(command.Usages()),
 		help.OptionErr(operatorErr),
+		help.OptionShowHelp(hint == "" && operatorErr == ""),
 	)
 	if err != nil {
 		return EPerm, errors.WithStack(err)

--- a/cli.go
+++ b/cli.go
@@ -312,7 +312,7 @@ func (c *CLI) Run(args []string) (Errno, error) {
 	}
 
 	// Run the command
-	if err := command.FlagSet().Parse(c.args.SubCommandArgs()); err != nil {
+	if err := command.FlagSet().Parse(c.args.SubCommandFlags()); err != nil {
 		return c.commandHelp(command, err.Error())
 	}
 
@@ -327,13 +327,7 @@ func (c *CLI) Run(args []string) (Errno, error) {
 	}
 
 	// Remove the flags, those are handled by the flagset.
-	var subCmdArgs []string
-	for _, v := range c.args.SubCommandArgs() {
-		if !strings.HasPrefix(v, "-") {
-			subCmdArgs = append(subCmdArgs, v)
-		}
-	}
-	if err := command.Init(subCmdArgs, c.args.Debug()); err != nil {
+	if err := command.Init(c.args.SubCommandArgs(), c.args.Debug()); err != nil {
 		return c.commandHelp(command, err.Error())
 	}
 

--- a/commands/text.go
+++ b/commands/text.go
@@ -28,7 +28,7 @@ func NewText(help, synopsis string) *Text {
 	return &Text{
 		helpText:     help,
 		synopsisText: strings.TrimSpace(synopsis),
-		flagSet:      flagset.New("text-command", flag.ExitOnError),
+		flagSet:      flagset.New("text-command", flag.ContinueOnError),
 	}
 }
 

--- a/example/cmd_config_show.go
+++ b/example/cmd_config_show.go
@@ -15,6 +15,7 @@ type configShowCmd struct {
 	flagSet *flagset.FlagSet
 
 	template string
+	test     bool
 	server   bool
 }
 
@@ -29,6 +30,7 @@ func configShowCmdFn(ui clui.UI) clui.Command {
 
 func (v *configShowCmd) init() {
 	v.flagSet.StringVar(&v.template, "template", "{{.Key}}	{{.Value}}", "Template for show key and values")
+	v.flagSet.BoolVar(&v.test, "test", false, "test")
 }
 
 func (v *configShowCmd) FlagSet() *flagset.FlagSet {

--- a/example/main.go
+++ b/example/main.go
@@ -14,10 +14,12 @@ func main() {
 	cli := clui.New("example", "1.0.0", "EXAMPLE", clui.OptionFileSystem(fsys))
 	cli.Add("version", versionCmdFn)
 	cli.Add("config show", configShowCmdFn)
+	cli.Add("config show something", configShowCmdFn)
 
 	code, err := cli.Run(os.Args[1:])
 	if err != nil {
-		log.Fatal(">>", err)
+		log.Fatal(">>", err, code)
 	}
+
 	os.Exit(code.Code())
 }

--- a/find.go
+++ b/find.go
@@ -10,7 +10,7 @@ import (
 
 // FindChildren returns the sub commands.
 // This will only contain immediate sub commands.
-func FindChildren(commands *group.Group, prefix string) (map[string]Command, error) {
+func FindChildren(commands *group.Group, prefix string, includeSubKeys bool) (map[string]Command, error) {
 	// if our prefix isn't empty, make sure it ends in ' '
 	if prefix != "" && prefix[len(prefix)-1] != ' ' {
 		prefix += " "
@@ -20,9 +20,11 @@ func FindChildren(commands *group.Group, prefix string) (map[string]Command, err
 	var keys []string
 	commands.WalkPrefix(prefix, func(k string, v radix.Value) bool {
 		// Ignore any sub-sub keys, i.e. "foo bar baz" when we want "foo bar"
-		if !strings.Contains(k[len(prefix):], " ") {
-			keys = append(keys, k)
+		if !includeSubKeys && strings.Contains(k[len(prefix):], " ") {
+			return false
 		}
+
+		keys = append(keys, k)
 
 		return false
 	})

--- a/find_test.go
+++ b/find_test.go
@@ -13,7 +13,7 @@ func TestFindChildren(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		group := group.New()
-		children, err := FindChildren(group, "")
+		children, err := FindChildren(group, "", true)
 		if expected, actual := true, err == nil; expected != actual {
 			t.Errorf("expected: %v, actual: %v, err: %v", expected, actual, err)
 		}
@@ -24,7 +24,7 @@ func TestFindChildren(t *testing.T) {
 
 	t.Run("empty group", func(t *testing.T) {
 		group := group.New()
-		children, err := FindChildren(group, "foo bar")
+		children, err := FindChildren(group, "foo bar", true)
 		if expected, actual := true, err == nil; expected != actual {
 			t.Errorf("expected: %v, actual: %v, err: %v", expected, actual, err)
 		}
@@ -37,7 +37,7 @@ func TestFindChildren(t *testing.T) {
 		group := group.New()
 		group.Add("foo bar", nil)
 
-		_, err := FindChildren(group, "foo")
+		_, err := FindChildren(group, "foo", true)
 		if expected, actual := "not found: \"foo bar\"", err.Error(); expected != actual {
 			t.Errorf("expected: %v, actual: %v, err: %v", expected, actual, err)
 		}
@@ -51,8 +51,27 @@ func TestFindChildren(t *testing.T) {
 
 		group := group.New()
 		group.Add("foo bar", cmd)
+		group.Add("foo bar sub", cmd)
 
-		children, err := FindChildren(group, "foo")
+		children, err := FindChildren(group, "foo", true)
+		if expected, actual := true, err == nil; expected != actual {
+			t.Errorf("expected: %v, actual: %v, err: %v", expected, actual, err)
+		}
+		if expected, actual := map[string]Command{"foo bar": cmd, "foo bar sub": cmd}, children; !reflect.DeepEqual(expected, actual) {
+			t.Errorf("expected: %v, actual: %v", expected, actual)
+		}
+	})
+
+	t.Run("group no subs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		cmd := NewMockCommand(ctrl)
+
+		group := group.New()
+		group.Add("foo bar", cmd)
+
+		children, err := FindChildren(group, "foo", false)
 		if expected, actual := true, err == nil; expected != actual {
 			t.Errorf("expected: %v, actual: %v, err: %v", expected, actual, err)
 		}

--- a/help/help.go
+++ b/help/help.go
@@ -30,6 +30,7 @@ type HelpOptions interface {
 	SetFormat(string)
 	SetColor(bool)
 	SetTemplate(string)
+	SetShowHelp(bool)
 }
 
 // HelpOption captures a tweak that can be applied to the Help.
@@ -46,6 +47,7 @@ type help struct {
 	usages   []string
 	format   string
 	color    bool
+	showHelp bool
 	template string
 }
 
@@ -83,6 +85,10 @@ func (s *help) SetFormat(p string) {
 
 func (s *help) SetColor(p bool) {
 	s.color = p
+}
+
+func (s *help) SetShowHelp(p bool) {
+	s.showHelp = p
 }
 
 func (s *help) SetTemplate(p string) {
@@ -169,6 +175,14 @@ func OptionTemplate(i string) HelpOption {
 	}
 }
 
+// OptionShowHelp allows the setting a color option to configure
+// the group.
+func OptionShowHelp(i bool) HelpOption {
+	return func(opt HelpOptions) {
+		opt.SetShowHelp(i)
+	}
+}
+
 // Func is the type of the function that is responsible for generating the
 // help output when the CLI must show the general help text.
 type Func func(...HelpOption) (string, error)
@@ -228,6 +242,7 @@ func BasicFunc(name string) Func {
 			Commands []nameHelp
 			Flags    []string
 			Usages   []string
+			ShowHelp bool
 		}{
 			Name:     name,
 			Header:   opt.header,
@@ -237,6 +252,7 @@ func BasicFunc(name string) Func {
 			Commands: serialized,
 			Flags:    opt.flags,
 			Usages:   opt.usages,
+			ShowHelp: opt.showHelp,
 		}); err != nil {
 			return "", errors.WithStack(err)
 		}

--- a/help/templates.go
+++ b/help/templates.go
@@ -12,6 +12,7 @@ const BasicHelpTemplate = `
 Did you mean?
         {{green .Hint}}
 {{end}}
+{{- if .ShowHelp }}
 Usage: {{green .Name}} [--version] [--help] [--debug] <command> [<args>]
 
 {{- if gt (len .Commands) 0 }}
@@ -27,6 +28,7 @@ Global Flags:
         --debug        Show all debug messages
     -h, --help         Print command help
         --version      Print client version
+{{- end}}
 `
 
 // CommandHelpTemplate represents a template for rendering the help for commands
@@ -36,12 +38,15 @@ const CommandHelpTemplate = `
 Found some issues:
 
     {{red .Err}}
+
+See {{ print " --help" | print .Name | green }} for more information.
 {{end -}}
 {{- if .Hint }}
 Did you mean?
     {{printf "%s\n" .Hint | green}}
 
 {{end -}}
+{{- if .ShowHelp }}
 {{- if .Name}}
 Usage:
 
@@ -75,4 +80,5 @@ Global Flags:
         --debug        Show all debug messages
     -h, --help         Print command help
         --version      Print client version
+{{- end}}
 `


### PR DESCRIPTION
The following only shows the help if there aren't any hints or errors.
This cleans up the UI/UX a bit for the CLI as it's clearer to see what
the output of the command is.