### PR TITLE
REPL shell

### DIFF
--- a/commands/shell.go
+++ b/commands/shell.go
@@ -1,0 +1,217 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/chzyer/readline"
+	"github.com/pkg/errors"
+	"github.com/spoke-d/clui/flagset"
+	"github.com/spoke-d/clui/radix"
+	"github.com/spoke-d/task/group"
+)
+
+// Runnable allows the shell to interact with a given runnable type.
+type Runnable interface {
+	// Run runs the actual CLI bases on the arguments given.
+	Run(args []string) (int, error)
+}
+
+// Store holds the command prefixes to able to walk over.
+type Store interface {
+	// WalkPrefix is used to walk the tree under a prefix
+	WalkPrefix(prefix string, fn radix.WalkFn)
+}
+
+// Shell defines a REPL that can be interactively accessed.
+type Shell struct {
+	flagSet *flagset.FlagSet
+	runner  Runnable
+	group   Store
+}
+
+// NewShell creates a REPL from a runnable and a command store.
+func NewShell(runner Runnable, group Store) *Shell {
+	return &Shell{
+		flagSet: flagset.New("text-command", flag.ContinueOnError),
+		runner:  runner,
+		group:   group,
+	}
+}
+
+// FlagSet returns the FlagSet associated with the command. All the flags are
+// parsed before running the command.
+func (c *Shell) FlagSet() *flagset.FlagSet {
+	return c.flagSet
+}
+
+// Usages returns various usages that can be used for the command.
+func (c *Shell) Usages() []string {
+	return make([]string, 0)
+}
+
+var firstPrompt = `
+Welcome to the interactive shell.
+Type "help" to see a list of available commands.
+Type ^D or ^C to quit.
+`[1:]
+
+// Help should return a long-form help text that includes the command-line
+// usage. A brief few sentences explaining the function of the command, and
+// the complete list of flags the command accepts.
+func (c *Shell) Help() string {
+	return `
+The shell command allows REPL functionality for interacting with
+the commands for the given CLI. All arguments and flags are then
+parsed and forwared to the correct command.
+
+Type ^D or ^C to exit the shell.`
+}
+
+// Synopsis should return a one-line, short synopsis of the command.
+// This should be short (50 characters of less ideally).
+func (c *Shell) Synopsis() string {
+	return "Shell command invokes a REPL for command interaction."
+}
+
+// Init is called with all the args required to run a command.
+// This is separated from Run, to allow the preperation of a command, before
+// it's run.
+func (c *Shell) Init([]string, CommandContext) error {
+	return nil
+}
+
+// Run subscribes to the group for executing the various run commands.
+// The subscriptions to the group are handled by the callee.
+func (c *Shell) Run(group *group.Group) {
+	group.Add(func(context.Context) error {
+		history, err := ioutil.TempFile("", "convoy-shell")
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		defer history.Close()
+
+		line, err := readline.NewEx(&readline.Config{
+			HistoryFile:     history.Name(),
+			Stdin:           readline.NewCancelableStdin(os.Stdin),
+			Stdout:          os.Stdout,
+			Stderr:          os.Stderr,
+			Prompt:          "\033[31m»\033[0m ",
+			InterruptPrompt: "^C",
+			EOFPrompt:       "exit",
+			AutoComplete:    generateCompletions(c.group),
+		})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		defer line.Close()
+
+		first := true
+		for {
+			if first {
+				fmt.Fprintln(os.Stdout, firstPrompt)
+				first = false
+			}
+
+			data, err := line.Readline()
+			if err == readline.ErrInterrupt {
+				if len(data) == 0 {
+					break
+				} else {
+					continue
+				}
+			} else if err == io.EOF {
+				break
+			}
+
+			if cmd := strings.TrimSpace(data); cmd == "help commands" {
+				fmt.Fprintln(os.Stdout, listAllCommands(c.group))
+				continue
+			} else if cmd == "help" {
+				fmt.Fprintln(os.Stdout, "Type ^D or ^C to exit the shell.")
+				continue
+			} else if cmd == "exit" {
+				return nil
+			}
+
+			if _, err := c.runner.Run(strings.Split(data, " ")); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
+		}
+
+		return nil
+	}, Disguard)
+}
+
+func listAllCommands(group Store) string {
+	var commands []string
+	group.WalkPrefix("", func(name string, value radix.Value) bool {
+		commands = append(commands, name)
+		return false
+	})
+	return strings.Join(commands, "\n")
+}
+
+func generateCompletions(group Store) *readline.PrefixCompleter {
+	nodes := node{
+		name:     "",
+		children: make(map[string]node),
+	}
+	group.WalkPrefix("", func(name string, value radix.Value) bool {
+		names := strings.Split(name, " ")
+		parent := nodes
+		for _, n := range names {
+			if _, ok := parent.children[n]; ok {
+				parent = parent.children[n]
+				continue
+			}
+			m := node{
+				name:     n,
+				children: make(map[string]node),
+			}
+
+			parent.children[n] = m
+			parent = m
+		}
+		return false
+	})
+	var recursive func(nodes node) []readline.PrefixCompleterInterface
+	recursive = func(nodes node) []readline.PrefixCompleterInterface {
+		if len(nodes.children) == 0 {
+			return []readline.PrefixCompleterInterface{
+				readline.PcItem(nodes.name),
+			}
+		}
+
+		items := make([]readline.PrefixCompleterInterface, 0)
+		for _, node := range nodes.children {
+			items = append(items, recursive(node)...)
+		}
+		return []readline.PrefixCompleterInterface{
+			readline.PcItem(nodes.name, items...),
+		}
+	}
+
+	items := recursive(nodes)
+	if len(items) != 1 {
+		return readline.NewPrefixCompleter()
+	}
+	generated := items[0].(*readline.PrefixCompleter).Children
+	root := []readline.PrefixCompleterInterface{
+		readline.PcItem("help",
+			readline.PcItem("commands"),
+		),
+		readline.PcItem("exit"),
+	}
+	return readline.NewPrefixCompleter(append(root, generated...)...)
+}
+
+type node struct {
+	name     string
+	children map[string]node
+}

--- a/example/main.go
+++ b/example/main.go
@@ -15,6 +15,8 @@ func main() {
 	cli.Add("version", versionCmdFn)
 	cli.Add("config show", configShowCmdFn)
 	cli.Add("config show something", configShowCmdFn)
+	cli.Add("config show else", configShowCmdFn)
+	cli.Add("config list", configShowCmdFn)
 
 	code, err := cli.Run(os.Args[1:])
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/spoke-d/clui
 go 1.13
 
 require (
+	github.com/chzyer/logex v1.1.10 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/golang/mock v1.4.0
 	github.com/mattn/go-isatty v0.0.11
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0 h1:Rd1kQnQu0Hq3qvJppYSG0HtP+f5LPPUiDswTLiEegLg=


### PR DESCRIPTION
The following adds a REPL shell to all commands. It's ideal for
interacting with the underlying command tree in a fast iterative
pattern.

```
go run ./example shell
```